### PR TITLE
🚀 change the localeIdAdapter option to sync or async function

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ export const getDefaultDocumentNode = ({ schemaType }) => {
             },
           ],
           /**
-           * Optional function used on translation import to Sanity, if the
-           * locale codes used by the translation vendor don't match Sanity's.
-           * Receives the vendor locale ID and returns the corresponding Sanity id.
+           * Optional sync or async function used on translation import to
+           * Sanity, if the locale codes used by the translation vendor don't
+           * match Sanity's. Receives the vendor locale ID and returns the
+           * corresponding Sanity ID.
            */
           localeIdAdapter: translationVendorId => sanityId,
         }),

--- a/src/components/TaskView.tsx
+++ b/src/components/TaskView.tsx
@@ -36,9 +36,6 @@ export const TaskView = ({ task, locales, refreshTask }: JobProps) => {
 
     const locale = getLocale(localeId, locales)
     const localeTitle = locale?.description || localeId
-    const sanityId = context.localeIdAdapter
-      ? context.localeIdAdapter(localeId)
-      : localeId
 
     try {
       const translation = await context.adapter.getTranslation(
@@ -46,6 +43,11 @@ export const TaskView = ({ task, locales, refreshTask }: JobProps) => {
         localeId,
         context.secrets
       )
+
+      const sanityId = context.localeIdAdapter
+        ? await context.localeIdAdapter(localeId)
+        : localeId
+
       await context.importTranslation(sanityId, translation)
 
       toast.push({

--- a/src/components/TranslationContext.tsx
+++ b/src/components/TranslationContext.tsx
@@ -12,7 +12,7 @@ export type ContextProps = {
   baseLanguage: string
   secrets: Secrets
   workflowOptions?: WorkflowIdentifiers[]
-  localeIdAdapter?: (id: string) => string
+  localeIdAdapter?: (id: string) => string | Promise<string>
 }
 
 export const TranslationContext = React.createContext<ContextProps | null>(null)


### PR DESCRIPTION
Adding the possibility of `localeIdAdapter` be async function it opens possibilities dynamically add or remove IDs without the need of sanity deploy