### PR TITLE
fix: remove hardcoded "base language" during field-level translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ export const getDefaultDocumentNode = ({ schemaType }) => {
            * corresponding Sanity ID.
            */
           localeIdAdapter: translationVendorId => sanityId,
+
+          /**
+           * For field-level translations, the key for the "source content"
+           *  (e.g. "en" or "en_US").
+           */
+          baseLanguage: 'en_US',
         }),
     ])
   }

--- a/src/components/TranslationsTab.tsx
+++ b/src/components/TranslationsTab.tsx
@@ -31,7 +31,8 @@ type TranslationTabProps = {
       id: string,
       localeId: string,
       doc: Record<string, any>,
-      idStructure?: 'subpath' | 'delimiter'
+      idStructure?: 'subpath' | 'delimiter',
+      baseLanguage?: string
     ) => Promise<void>
     idStructure?: 'subpath' | 'delimiter'
     workflowOptions?: WorkflowIdentifiers[]
@@ -64,8 +65,15 @@ const TranslationTab = (props: TranslationTabProps) => {
     }
 
     const importTranslation = (localeId: string, doc: Record<string, any>) => {
+      const baseLanguage = props.options.baseLanguage
       const idStructure = props.options.idStructure
-      return importTranslationFunc(documentId, localeId, doc, idStructure)
+      return importTranslationFunc(
+        documentId,
+        localeId,
+        doc,
+        idStructure,
+        baseLanguage
+      )
     }
 
     const exportTranslationFunc = props.options.exportForTranslation

--- a/src/configuration/baseFieldLevelConfig.ts
+++ b/src/configuration/baseFieldLevelConfig.ts
@@ -28,7 +28,13 @@ export const baseFieldLevelConfig = {
     serialized.name = id
     return serialized
   },
-  importTranslation: async (id: string, localeId: string, document: string) => {
+  importTranslation: async (
+    id: string,
+    localeId: string,
+    document: string,
+    _idStructure: undefined,
+    baseLanguage: string = 'en'
+  ) => {
     const serializationVersion = checkSerializationVersion(document)
     let deserialized
     if (serializationVersion === '2') {
@@ -40,7 +46,7 @@ export const baseFieldLevelConfig = {
         schemas
       ).deserializeDocument(document) as SanityDocument
     }
-    return fieldLevelPatch(id, deserialized, localeId)
+    return fieldLevelPatch(id, deserialized, localeId, baseLanguage)
   },
   adapter: DummyAdapter,
   secretsNamespace: 'translationService',
@@ -49,7 +55,8 @@ export const baseFieldLevelConfig = {
 export const fieldLevelPatch = async (
   documentId: string,
   translatedFields: SanityDocument,
-  localeId: string
+  localeId: string,
+  baseLanguage: string = 'en'
 ) => {
   let baseDoc: SanityDocument
   if (translatedFields._rev && translatedFields._id) {
@@ -65,7 +72,7 @@ export const fieldLevelPatch = async (
     translatedFields,
     baseDoc,
     localeId,
-    'en'
+    baseLanguage
   )
 
   await client


### PR DESCRIPTION
* add optional `baseLanguage` parameter to `options.importForTranslation` prop in `TranslationsTab`
* update `baseFieldlevelConfig` to have same signature for `importTranslation` and then call `fieldLevelPatch` with `baseLanguage`

fixes: #16 