### PR TITLE
feat(newTask): support locales being selected by default

### DIFF
--- a/src/components/NewTask.tsx
+++ b/src/components/NewTask.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, ChangeEvent } from 'react'
+import React, { useState, useContext, ChangeEvent, useEffect } from 'react'
 import styled from 'styled-components'
 import {
   Button,
@@ -65,6 +65,17 @@ export const NewTask = ({ locales, refreshTask }: Props) => {
   const [selectedLocales, setSelectedLocales] = useState<React.ReactText[]>([])
   const [selectedWorkflowUid, setSelectedWorkflowUid] = useState<string>()
   const [isBusy, setIsBusy] = useState(false)
+
+  useEffect(
+    function preselectLocales() {
+      setSelectedLocales(
+        locales
+          .filter(locale => locale.enabled !== false && locale.selected)
+          .map(locale => locale.localeId)
+      )
+    },
+    [locales]
+  )
 
   const context = useContext(TranslationContext)
   const toast = useToast()

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type TranslationLocale = {
   localeId: string
   description: string
   enabled?: boolean
+  selected?: boolean
 }
 
 export type TranslationTaskLocaleStatus = {


### PR DESCRIPTION
This change allows the locales returned by `getLocales` to include an optional `selected` property.

When set to "true", and the existing `enabled` property is not explicitly set to "false", this will pre-select the corresponding locale's button.