### PR TITLE
feat: support sanity-plugin-internationalized-array v5 metadata format

### DIFF
--- a/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts
+++ b/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts
@@ -46,8 +46,10 @@ export const documentLevelPatch = async (
   }
 
   //the id of the translated document should be on the metadata if it exists
+  // Match by v5 `language` field, with a fallback to legacy v4 `_key` so that documents
+  // created before sanity-plugin-internationalized-array v5 continue to resolve.
   const i18nDocId = (translationMetadata.translations as Array<Record<string, any>>).find(
-    (translation) => translation._key === localeId,
+    (translation) => translation.language === localeId || translation._key === localeId,
   )?.value?._ref
 
   if (i18nDocId) {

--- a/src/configuration/baseDocumentLevelConfig/helpers/createI18nDocAndPatchMetadata.ts
+++ b/src/configuration/baseDocumentLevelConfig/helpers/createI18nDocAndPatchMetadata.ts
@@ -1,4 +1,5 @@
 import {SanityClient, SanityDocumentLike} from 'sanity'
+import {randomKey} from '@sanity/util/content'
 
 export const createI18nDocAndPatchMetadata = (
   translatedDoc: SanityDocumentLike,
@@ -9,9 +10,15 @@ export const createI18nDocAndPatchMetadata = (
 ): void => {
   translatedDoc[languageField] = localeId
   const translations = translationMetadata.translations as Record<string, any>[]
-  const existingLocaleKey = translations.find((translation) => translation._key === localeId)
-  const operation = existingLocaleKey ? 'replace' : 'after'
-  const location = existingLocaleKey ? `translations[_key == "${localeId}"]` : 'translations[-1]'
+  // Match by v5 `language` field, falling back to legacy v4 `_key` so that documents
+  // created before sanity-plugin-internationalized-array v5 are still updated in-place.
+  const existingLocaleEntry = translations.find(
+    (translation) => translation.language === localeId || translation._key === localeId,
+  )
+  const operation = existingLocaleEntry ? 'replace' : 'after'
+  const location = existingLocaleEntry
+    ? `translations[language == "${localeId}" || _key == "${localeId}"]`
+    : 'translations[-1]'
 
   //remove system fields
   const {_updatedAt, _createdAt, ...rest} = translatedDoc
@@ -22,8 +29,11 @@ export const createI18nDocAndPatchMetadata = (
       .patch(translationMetadata._id, (p) =>
         p.insert(operation, location, [
           {
-            _key: localeId,
+            // sanity-plugin-internationalized-array v5 stores the locale on a dedicated
+            // `language` field and expects `_key` to be a unique random key.
+            _key: randomKey(),
             _type: 'internationalizedArrayReferenceValue',
+            language: localeId,
             value: {
               _type: 'reference',
               _ref,

--- a/src/configuration/baseDocumentLevelConfig/helpers/createTranslationMetadata.ts
+++ b/src/configuration/baseDocumentLevelConfig/helpers/createTranslationMetadata.ts
@@ -1,7 +1,9 @@
 import {KeyedObject, Reference, SanityClient, SanityDocumentLike} from 'sanity'
+import {randomKey} from '@sanity/util/content'
 
 type TranslationReference = KeyedObject & {
   _type: 'internationalizedArrayReferenceValue'
+  language: string
   value: Reference
 }
 
@@ -11,8 +13,11 @@ export const createTranslationMetadata = (
   baseLanguage: string,
 ): Promise<SanityDocumentLike> => {
   const baseLangEntry: TranslationReference = {
-    _key: baseLanguage,
+    // sanity-plugin-internationalized-array v5 stores the locale on a dedicated
+    // `language` field and expects `_key` to be a unique random key.
+    _key: randomKey(),
     _type: 'internationalizedArrayReferenceValue',
+    language: baseLanguage,
     value: {
       _type: 'reference',
       _ref: document._id.replace('drafts.', ''),

--- a/src/configuration/baseDocumentLevelConfig/helpers/getTranslationMetadata.ts
+++ b/src/configuration/baseDocumentLevelConfig/helpers/getTranslationMetadata.ts
@@ -5,10 +5,13 @@ export const getTranslationMetadata = (
   client: SanityClient,
   baseLanguage: string,
 ): Promise<SanityDocumentLike | null> => {
+  // Match by v5 `language` field first, falling back to legacy v4 `_key` so existing
+  // metadata documents created before sanity-plugin-internationalized-array v5 keep
+  // resolving while users migrate their content.
   return client.fetch(
     `*[
         _type == 'translation.metadata' &&
-        translations[_key == $baseLanguage][0].value._ref == $id
+        translations[language == $baseLanguage || _key == $baseLanguage][0].value._ref == $id
       ][0]`,
     {baseLanguage, id},
   )


### PR DESCRIPTION
## Summary

`sanity-plugin-internationalized-array@5` stores the locale identifier on a dedicated `language` field instead of `_key`, and treats `_key` as a unique random key per array item. The current document-level config still reads and writes `translation.metadata.translations[]` entries using the legacy v4 shape (`_key === localeId`).

That means metadata produced by this package:

- shows up as "needs migration" in the v5 plugin's UI; and
- is invisible to downstream queries that filter on `language`.

## Changes

Document-level helpers updated to be **read-both / write-v5**:

- `getTranslationMetadata` – GROQ filter accepts `language == $baseLanguage || _key == $baseLanguage` so existing v4 metadata keeps resolving while content is migrated.
- `documentLevelPatch` / `createI18nDocAndPatchMetadata` – match the existing locale entry by `language` first with a `_key` fallback. The replace-selector uses the same OR clause so v4 entries are upgraded in place on re-import.
- `createTranslationMetadata` / `createI18nDocAndPatchMetadata` – new entries are written in v5 shape: random `_key` from `@sanity/util/content`'s `randomKey` plus a dedicated `language` field. Type definition updated to require `language: string`.

No schema or API changes. Field-level (`baseFieldLevelConfig`) and i18n-array (`baseI18nArrayConfig`) configs are not touched here — only document-level metadata is affected by this issue.

## Migration story

- Documents created via this package after the change are written as v5.
- Existing v4 metadata documents continue to be readable.
- When a document is re-imported, the replace-selector matches both shapes and the entry is rewritten as v5 — no separate data migration required.
- Users can still run the plugin's `migrateToLanguageField` migration if they want to upgrade in bulk.

## Test plan

- [ ] Run `tsc --build` (clean — types updated for new `language` field on `TranslationReference`).
- [ ] Manual verification with `sanity-plugin-studio-smartling` and `@sanity/document-internationalization@6` (which depends on `sanity-plugin-internationalized-array@5`):
  - [ ] Importing a translation for a doc with no metadata creates `translation.metadata` with both base and target entries in v5 format.
  - [ ] Importing a translation for a doc with existing v4 metadata replaces the matched entry with a v5 entry, leaves other entries untouched.
  - [ ] Re-importing the base language replaces the base entry as v5.
  - [ ] After import, the v5 plugin no longer reports the entries as needing migration.